### PR TITLE
Strict

### DIFF
--- a/constants/errors.js
+++ b/constants/errors.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const ERROR = "Error: ";
 
 const FILE_NOT_FOUND    = ERROR + "File not found";

--- a/constants/globals.js
+++ b/constants/globals.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const CONFIG_FILE   = "cleave-html-config.json";
 const FILE_TYPE     = "utf8"; 
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,1 @@
+"use strict";

--- a/reader.js
+++ b/reader.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const getConfig = require('./reader/config_reader.js');
 
 getConfig().then(data => {

--- a/reader.js
+++ b/reader.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const getConfig = require('./reader/config_reader.js');
+const { getConfig } = require('./reader/config_reader.js');
 
 getConfig().then(data => {
     console.log("Config File Read and Validated. Final Ouput: \n", data);

--- a/reader/config_reader.js
+++ b/reader/config_reader.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs        = require('fs-extra');
 const R         = require('ramda');
 const e         = require("../constants/errors");
@@ -64,4 +66,8 @@ const getConfig = () => {
     return jsonReader(file_name).then(validateConfig);
 }
 
-module.exports = getConfig;
+module.exports = {
+    getConfig,
+    jsonReader,
+    validateConfig
+};

--- a/tests/helpers/typecheck_test.js
+++ b/tests/helpers/typecheck_test.js
@@ -1,0 +1,1 @@
+"use strict";

--- a/tests/reader/config_reader_test.js
+++ b/tests/reader/config_reader_test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs                = require('fs');
 const chai              = require('chai');
 const chai_as_promised  = require('chai-as-promised');
@@ -47,7 +49,7 @@ describe('JSON Reader', function() {
 });
 
 describe('Check Config', function() {
-    const {checkConfig} = config_reader; 
+    const {validateConfig} = config_reader; 
 
     it('should throw no errors for a valid object', function() {
         const obj = {
@@ -55,12 +57,12 @@ describe('Check Config', function() {
             destination: "static",
         };
 
-        chai.expect(checkConfig(obj)).to.equal(undefined);
+        chai.expect(validateConfig(obj)).to.eventually.equal(undefined);
     });
 
     it('should throw an error absent source or destination', function() {
-        chai.expect(() => checkConfig({source: ["a"]})).to.throw(e.config.INVALID_DST);
-        chai.expect(() => checkConfig({destination: "a"})).to.throw(e.config.INVALID_SRC);
+        chai.expect(validateConfig({source: ["a"]})).to.be.rejectedWith(e.config.INVALID_DST);
+        chai.expect(validateConfig({destination: "a"})).to.be.rejectedWith(e.config.INVALID_SRC);
     });
 
     it('should throw an error for incorrect source', function() {
@@ -69,10 +71,10 @@ describe('Check Config', function() {
         }
 
         obj.source = "";
-        chai.expect(() => checkConfig(obj)).to.throw(e.config.INVALID_SRC);
+        chai.expect(validateConfig(obj)).to.be.rejectedWith(e.config.INVALID_SRC);
 
         obj.source = [1];
-        chai.expect(() => checkConfig(obj)).to.throw(e.config.INVALID_SRC);
+        chai.expect(validateConfig(obj)).to.be.rejectedWith(e.config.INVALID_SRC);
     });
 
     it('should throw an error for incorrect destination', function() {
@@ -81,9 +83,9 @@ describe('Check Config', function() {
         }
 
         obj.destination = [];
-        chai.expect(() => checkConfig(obj)).to.throw(e.config.INVALID_DST);
+        chai.expect(validateConfig(obj)).to.be.rejectedWith(e.config.INVALID_DST);
 
         obj.destination = 1;
-        chai.expect(() => checkConfig(obj)).to.throw(e.config.INVALID_DST);
+        chai.expect(validateConfig(obj)).to.be.rejectedWith(e.config.INVALID_DST);
     });
 });


### PR DESCRIPTION
1 - I think using strict mode would be better for avoiding errors.
2 - I didn't catch this in the PR you made, but just exporting `getConfig` in `config_reader.js` doesn't allow the tests to individually test the functions. if there's another way around that, I'm down for it. But I can't think of another way.