### PR TITLE
removed instances of use strict

### DIFF
--- a/constants/errors.js
+++ b/constants/errors.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const ERROR = "Error: ";
 
 const FILE_NOT_FOUND    = ERROR + "File not found";

--- a/constants/globals.js
+++ b/constants/globals.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const CONFIG_FILE   = "cleave-html-config.json";
 const FILE_TYPE     = "utf8"; 
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-'use strict';

--- a/parser.js
+++ b/parser.js
@@ -1,1 +1,0 @@
-"use strict";

--- a/reader.js
+++ b/reader.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const { getConfig } = require('./reader/config_reader.js');
 
 getConfig().then(data => {

--- a/reader/config_reader.js
+++ b/reader/config_reader.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const fs        = require('fs-extra');
 const R         = require('ramda');
 const e         = require("../constants/errors");

--- a/tests/helpers/typecheck_test.js
+++ b/tests/helpers/typecheck_test.js
@@ -1,1 +1,0 @@
-"use strict";

--- a/tests/reader/config_reader_test.js
+++ b/tests/reader/config_reader_test.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const fs                = require('fs');
 const chai              = require('chai');
 const chai_as_promised  = require('chai-as-promised');


### PR DESCRIPTION
So apparently `const` and `let` don't work with `'use strict'` unless you run the file in node with the `--harmony` flag. 
It's because it's ES2015 or something as explained [here](https://stackoverflow.com/questions/22603078/syntaxerror-use-of-const-in-strict-mode)