### PR TITLE
[WIP] added document tree object

### DIFF
--- a/constants/errors.js
+++ b/constants/errors.js
@@ -15,7 +15,7 @@ const config = {
     CONFIG_ERROR,
     INVALID_SRC,
     INVALID_DST,
-}
+};
 /* -------------------- */
 
 /* AST Node errors */
@@ -35,7 +35,23 @@ const ast_node = {
     INVALID_ATTR_O,
     INVALID_TEXT_O,
     INVALID_COMMENT_O,
-}
+};
+/* -------------------- */
+
+/* Document Tree Errors */
+const INVALID_IMPORT    = ERROR + "Invalid import. Import needs to have a name and src attribute";
+const INVALID_I_ATTR    = ERROR + "Invalid import. Import name and path cannot be empty";
+const REPEATED_NAME     = ERROR + "Invalid name. Imported cleave names cannot be repeated";
+const INVALID_C_NODE    = ERROR + "Invalid cleave node.";
+const INVALID_T_NODE    = ERROR + "Invalid tag node";
+
+const doc_tree = {
+    INVALID_IMPORT,
+    INVALID_I_ATTR,
+    REPEATED_NAME,
+    INVALID_C_NODE,
+    INVALID_T_NODE
+};
 /* -------------------- */
 
 module.exports = Object.freeze({
@@ -43,4 +59,5 @@ module.exports = Object.freeze({
     INVALID_ARGUMENT,
     config,
     ast_node,
+    doc_tree,
 });

--- a/parser/doc_tree.js
+++ b/parser/doc_tree.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const R             = require("ramda"); 
+const e             = require("../constants/errors");
+const {Cleave, Tag} = require("./ast_nodes");
+
+function DocTree() {
+    //list of imports to verify if cleave nodes are valid
+    this.imports = {};
+    
+    //list of pointers to cleave nodes for quicker tree insertion
+    this.cleave_nodes = [];
+
+    //the html tree of the document
+    this.html = {};
+};
+
+DocTree.prototype.addImport = function(name, path) {
+
+    /* Error checks */
+    if(!R.is(String, name) || !R.is(String, path)) {
+        throw(e.doc_tree.INVALID_IMPORT);
+    }
+    if(isEmpty(name) || isEmpty(path)) {
+        throw(e.doc_tree.INVALID_I_ATTR);
+    }
+    if(this.imports[name]) {
+        throw(e.doc_tree.REPEATED_NAME);
+    }
+    /* ------------ */
+
+    this.imports[name] = path;
+};
+
+DocTree.prototype.addCleaveNode = function(node) {
+
+    /* Error checks */
+    if(!(node instanceof Cleave)) {
+        throw(e.doc_tree.INVALID_C_NODE);
+    }
+    /* ------------ */
+
+    this.cleave_nodes.push(node);
+};
+
+DocTree.prototype.addTree = function(tree) {
+
+    /* Error checks */
+    if(!(node instanceof Tag)) {
+        throw(e.doc_tree.INVALID_T_NODE);
+    }
+    /* ------------ */
+
+    this.html = tree;
+};
+
+function isEmpty(string) {
+    return (string.length === 0 || !string.trim());
+};
+
+const a = new DocTree();
+a.addImport("navbar", "/po/");
+
+module.exports = DocTree;


### PR DESCRIPTION
This is how I was thinking the document would be represented after being read.
```
{
  imports: {name="",  path=""}
  cleave_nodes: [],
  html: {}
}
```
`imports` will be a sort of hash for reference to see if the cleave node has been imported.
`cleave_nodes` will be a list that point to the cleave nodes in the tree.
`html` will be the document as the AST Tree.

Do you think this representation is good? could anything be improved?